### PR TITLE
fix extra whitespace

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     ports:
       - "8080:80"
       - "8443:443"
-   volumes:
+  volumes:
      - /etc/localtime:/etc/localtime             # to sync the container clock with localhost.
      - ./files/private:/var/www/files            # ojs' private files
      - ./files/public:/var/www/html/public       # ojs' public files


### PR DESCRIPTION
Hi!

This is an small fix in the yaml file to prevent a parse error.

Best, Roberto.