### PR TITLE
Let users specify git reference as buildarg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM alpine:3.7
 
 LABEL maintainer="Lucas G. Diedrich <lucas.diedrich@gmail.com>"
-
+ARG ref=ojs-3_1_1-4
 WORKDIR /var/www/html
 
 ENV COMPOSER_ALLOW_SUPERUSER=1  \
     SERVERNAME="localhost"      \
     HTTPS="on" \
-    OJS_VERSION="ojs-3_1_1-4"       \
+    OJS_VERSION=$ref       \
     OJS_CLI_INSTALL="0"         \
     OJS_DB_HOST="localhost"     \
     OJS_DB_USER="ojs"           \


### PR DESCRIPTION
This commit introduces a ``ref`` argument that let the users specify the
git reference (can be a branch, a tag, the SHA-1 of a commit) that they
want to use.

The default value of the ``ref`` argument is master, meaning the latest
version of OJS will always be used.